### PR TITLE
Do not return undefined as a string.

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -10,4 +10,7 @@ describe('idObj', () => {
   it('should support bracket notation', () => {
     expect(idObj[1]).toBe('1');
   });
+  it('should handle undefined appropriately', () => {
+    expect(idObj[undefined]).toBe(undefined);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,9 @@ idObj = new Proxy({}, {
     if (key === '__esModule') {
       return false;
     }
+    if (key === 'undefined') {
+      return undefined;
+    }
     return key;
   }
 });


### PR DESCRIPTION
Hi there! This is a great library. I noticed while using it, though, that it treats `undefined` as any other key. So when I'm snapshot testing some logic around classnames like this:

```javascript
const className = (color) => {
  return [
    style.button,
    style[color] ? style[color] : '',
  ].join(' ')
}
```

running a function like `className(undefined)` will result in a string that looks like `"button undefined"` even though the real-world behavior would result in a string like `"button "` (where `style` is an imported css module). 

I think this pull request needs to add cases to the other test files (I wasn't sure what was going on with those), but I wanted to throw it out to see what you think. Is this the intended behavior? Thanks!